### PR TITLE
Text field: use text/x-html-safe output format and only allow text/html input.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.0c2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Text field: use text/x-html-safe output format and only allow text/html input.
+  [jone]
 
 
 3.0c1 (2013-01-24)

--- a/simplelayout/types/common/content/simplelayout_schemas.py
+++ b/simplelayout/types/common/content/simplelayout_schemas.py
@@ -55,8 +55,11 @@ textSchema = atapi.Schema((
     atapi.TextField('text',
               required=False,
               searchable=True,
-              default_input_type = 'text/html',
-              default_output_type = 'text/html',
+              allowable_content_types=('text/html', ),
+              default_content_type='text/html',
+              validators=('isTidyHtmlWithCleanup', ),
+              default_input_type='text/html',
+              default_output_type='text/x-html-safe',
               widget = atapi.RichWidget(
                         description = '',
                         label = _(u'label_body_text', default=u'Body Text'),


### PR DESCRIPTION
- Add validator and use `text/x-html-safe` output format for preventing XSS
- Use only `text/html` as allowable content types, so that the format is not selectable in the WYSIWYG field

/cc @maethu
